### PR TITLE
Removed dependency to ghoneycutt/puppet-module-common

### DIFF
--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -45,7 +45,7 @@ class pam::limits (
   }
   if $::osfamily == 'Suse' and $::lsbmajdistrelease == '10'  {
   } else {
-    common::mkdir_p { $limits_d_dir: }
+    pam::mkdir_p { $limits_d_dir: }
     file { 'limits_d':
       ensure  => directory,
       path    => $limits_d_dir,

--- a/manifests/mkdir_p.pp
+++ b/manifests/mkdir_p.pp
@@ -1,0 +1,10 @@
+#
+# define pam::mkdir_p
+#
+define pam::mkdir_p {
+  exec { "mkdir_p-${name}":
+    command => "mkdir -p ${name}",
+    unless  => "test -d ${name}",
+    path    => '/bin:/usr/bin',
+  }
+}


### PR DESCRIPTION
puppet-module-common can cause conflicts with other modules, so just added one
resources used by pam to the pam module itself.